### PR TITLE
Quicker analysis

### DIFF
--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -15,14 +15,17 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     full = ui.input_settings$full
     part = ui.input_settings$part
     tilt = ui.input_settings$tilt
+    chop = 0
+    
   } else {
     gaps = 20
     full = 20
     part = 90
     tilt = 75
+    chop = 1
   }
 
- calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):
+  # calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):
   rate = as.numeric(data$datetime[2] - data$datetime[1])
   
   data.classified = data %>%

--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -4,6 +4,11 @@
 #### Functions to calculate Hydrodynamic indicators ####
 
 #' Function to predict inundation status, current and wave orbital velocities:
+# gaps: minimum gap in an inundation event to be closed (where points were misclassified as non inundated)
+# full: minimum duration of a fully inundated event (otherwise event is reclassified as partially inundated)
+# part: time window to search for partially inundated cases at the start and end of inundation events
+# tilt: minimum tilt to classify an event as fully inundated (otherwise event is reclassified as partially inundated)
+# chop: use a proportion of the data for abrupt shift detection (1 = all, 0 = none)
 get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
   if (is.data.frame(ui.input_settings)){
     gaps = ui.input_settings$gaps
@@ -16,12 +21,8 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     part = 90
     tilt = 75
   }
-  # gaps: minimum gap in an inundation event to be closed (where points were misclassified as non inundated)
-  # full: minimum duration of a fully inundated event (otherwise event is reclassified as partially inundated)
-  # part: time window to search for partially inundated cases at the start and end of inundation events
-  # tilt: minimum tilt to classify an event as fully inundated (otherwise event is reclassified as partially inundated)
 
-  # calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):
+ calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):
   rate = as.numeric(data$datetime[2] - data$datetime[1])
   
   data.classified = data %>%
@@ -101,7 +102,7 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
   # subset the data (now all = 1) to reduce CPU time if the search window is large:
   shift = df.s %>%
     group_by(Change) %>%
-    slice(round(seq(1, n(), length.out = (1 * n())), 0)) %>%
+    slice(round(seq(1, n(), length.out = (chop * n())), 0)) %>%
     mutate(
       # detect abrupt shifts (normalise to remove direction of shift):
       Shift = case_when(Tide == 'Flood' ~ as_detect(Tilt),

--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -15,14 +15,20 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     full = ui.input_settings$full
     part = ui.input_settings$part
     tilt = ui.input_settings$tilt
-    chop = 0
-    
+    chop = ui.input_settings$chop / 100
   } else {
     gaps = 20
     full = 20
     part = 90
     tilt = 75
-    chop = 1
+    chop = 0.5
+    if (chop < 1){
+      showNotification(paste("NOTE: ", chop * 100, 
+                             " % of the data are used in searching for partially 
+                           inundated cases. Refine proportion in custom settings.",
+                             sep = ""),
+                       type = "warning")
+    }
   }
 
   # calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -57,6 +57,11 @@ hyd.target.box.settings = function(){
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Tilt full inundation</abbr>"),
                      value = 75)          
       ),
+      sliderInput(inputId = "hydro.set.chop.target",
+                  label = HTML("<abbr title='Proportion of data to be used in searching for partially inundated cases (%)'>Proportion data</abbr>"),
+                  value = 50, step = 5,
+                  min = 20, max = 100,
+                  pre = "%"),
 
       actButton("hydro.set.apply.target", "Apply custom settings", "update"),
       actButton("hydro.set.reset.target", "Reset custom settings", "grey")
@@ -90,19 +95,10 @@ hyd.target.box.figures = function(){
     tabsetPanel(
       tabPanel("Daily inundation", br(),
                plotlyOutput("fig.inundation.target")),
-               # actButton("save.fig.inundation.target",
-               #           "Save figure", 
-               #           "saveFigure")),
       tabPanel("Current velocity", br(),
                plotlyOutput("fig.velocity.target")),
-               # actButton("save.fig.velocity.target",
-               #           "Save figure", 
-               #           "saveFigure")),
       tabPanel("Wave orbital velocity", br(),
                plotlyOutput("fig.wave.velocity.target")),
-               # actButton("save.fig.wave.velocity.target",
-               #           "Save figure", 
-               #           "saveFigure"))
     ),
     actButton("save.figs.target",
               "Download plots", 
@@ -167,6 +163,11 @@ hyd.reference.box.settings = function(){
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Tilt full inundation</abbr>"),
                      value = 75)
       ),
+      sliderInput(inputId = "hydro.set.chop.reference",
+                  label = HTML("<abbr title='Proportion of data to be used in searching for partially inundated cases (%)'>Proportion data</abbr>"),
+                  value = 50, step = 5,
+                  min = 20, max = 100,
+                  pre = "%"),
       
       actButton("hydro.set.apply.reference", "Apply custom settings", "update"),
       actButton("hydro.set.reset.reference", "Reset custom settings", "grey")

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -40,25 +40,25 @@ hyd.target.box.settings = function(){
     list(
       uiOutput("hydro.window.target.show"),
 
-      # Default values: gaps = 20, full = 20, part = 90, tilt = 75
+      # Default values: gaps = 20, full = 20, part = 90, tilt = 75, chop = 50
       splitLayout(
         numericInput(inputId = "hydro.set.gaps.target",
                      label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated (minutes)'>Minimum gap</abbr>"),
                      value = 20),
         numericInput(inputId = "hydro.set.part.target",
-                     label = HTML("<abbr title='Time window to search for partially inundated cases at the start and end of inundation events (minutes).'>Partial inundation window</abbr>"),
+                     label = HTML("<abbr title='Time window to search for partially inundated cases at the start and end of inundation events (minutes).'>Search window</abbr>"),
                      value = 90)
         ),
       splitLayout(
         numericInput(inputId = "hydro.set.full.target",
-                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated (minutes)'>Minimum full inundation</abbr>"),
+                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated (minutes)'>Minimum duration</abbr>"),
                      value = 20),
         numericInput(inputId = "hydro.set.tilt.target",
-                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Tilt full inundation</abbr>"),
+                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
                      value = 75)          
       ),
       sliderInput(inputId = "hydro.set.chop.target",
-                  label = HTML("<abbr title='Proportion of data to be used in searching for partially inundated cases (%)'>Proportion data</abbr>"),
+                  label = HTML("<abbr title='Using less data increases the speed of the analysis and has a minimal effect on the accuracy of detecting partially inundated cases. (%)'>Partial data search</abbr>"),
                   value = 50, step = 5,
                   min = 20, max = 100,
                   pre = "%"),
@@ -146,25 +146,25 @@ hyd.reference.box.settings = function(){
     list(
       uiOutput("hydro.window.reference.show"),
       
-      # Default values: gaps = 20, full = 20, part = 90, tilt = 75
+      # Default values: gaps = 20, full = 20, part = 90, tilt = 75, chop = 50
       splitLayout(
         numericInput(inputId = "hydro.set.gaps.reference",
                      label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated (minutes)'>Minimum gap</abbr>"),
                      value = 20),
         numericInput(inputId = "hydro.set.part.reference",
-                     label = HTML("<abbr title='Time window to search for partially inundated cases at the start and end of inundation events (minutes).'>Partial inundation window</abbr>"),
+                     label = HTML("<abbr title='Time window to search for partially inundated cases at the start and end of inundation events (minutes).'>Search window</abbr>"),
                      value = 90)
       ),
       splitLayout(
         numericInput(inputId = "hydro.set.full.reference",
-                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated (minutes)'>Minimum full inundation</abbr>"),
+                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated (minutes)'>Minimum duration</abbr>"),
                      value = 20),
         numericInput(inputId = "hydro.set.tilt.reference",
-                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Tilt full inundation</abbr>"),
+                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
                      value = 75)
       ),
       sliderInput(inputId = "hydro.set.chop.reference",
-                  label = HTML("<abbr title='Proportion of data to be used in searching for partially inundated cases (%)'>Proportion data</abbr>"),
+                  label = HTML("<abbr title='Using less data increases the speed of the analysis and has a minimal effect on the accuracy of detecting partially inundated cases. (%)'>Partial data search</abbr>"),
                   value = 50, step = 5,
                   min = 20, max = 100,
                   pre = "%"),

--- a/server.R
+++ b/server.R
@@ -771,7 +771,8 @@ shinyServer(function(input, output, session) {
     return(data.frame(gaps = input$hydro.set.gaps.target,
                       full = input$hydro.set.full.target,
                       part = input$hydro.set.part.target,
-                      tilt = input$hydro.set.tilt.target)
+                      tilt = input$hydro.set.tilt.target,
+                      chop = input$hydro.set.chop.target)
     )
   })
   
@@ -1018,7 +1019,8 @@ shinyServer(function(input, output, session) {
     return(data.frame(gaps = input$hydro.set.gaps.reference,
                       full = input$hydro.set.full.reference,
                       part = input$hydro.set.part.reference,
-                      tilt = input$hydro.set.tilt.reference)
+                      tilt = input$hydro.set.tilt.reference,
+                      chop = input$hydro.set.chop.reference)
     )
   })
   


### PR DESCRIPTION
Added a new argument to use a proportion of the data in detecting abrupt shifts. Testing showed using 25% of the data results in marked improvements in speed (i.e. chop = 0.25). Default is currently to use all the data (chop = 1), but maybe the default should be 25%.

- [ ] Cai - check how much the results change if 25% of the data is used for abrupt shift detection

