### PR TITLE
Simpler custom settings

### DIFF
--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -21,14 +21,7 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     full = 20
     part = 90
     tilt = 75
-    chop = 0.5
-    if (chop < 1 & nrow(data) > 0){
-      showNotification(paste("NOTE: ", chop * 100, 
-                             " % of the data are used in searching for partially 
-                           inundated cases. Refine proportion in custom settings.",
-                             sep = ""),
-                       type = "warning")
-    }
+    chop = 0.25
   }
 
   # calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):

--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -15,15 +15,14 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     full = ui.input_settings$full
     part = ui.input_settings$part
     tilt = ui.input_settings$tilt
-    chop = ui.input_settings$chop / 100
   } else {
     gaps = 20
     full = 20
     part = 90
     tilt = 75
-    chop = 0.25
   }
-
+  chop = 0.25
+  
   # calculate sampling rate (for selecting the correct current and wave orbital velocity calibration later on):
   rate = as.numeric(data$datetime[2] - data$datetime[1])
   

--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -525,7 +525,7 @@ get.comparison = function(hydro.t, hydro.r, stats.t, stats.r) {
   comparison = left_join(summary.c, event.c, by = c('Parameter', 'Units')) %>%
     filter(Parameter %in% c('Survey days',
                             'Inundation events',
-                            'Median inundation frequency',
+                            'Mean inundation frequency',
                             'Maximum Window of Opportunity',
                             'Inundation proportion',
                             'Mean current velocity', 

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -57,11 +57,6 @@ hyd.target.box.settings = function(){
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
                      value = 75)          
       ),
-      sliderInput(inputId = "hydro.set.chop.target",
-                  label = HTML("<abbr title='Using less data increases the speed of the analysis and has a minimal effect on the accuracy of detecting partially inundated cases. (%)'>Partial data search</abbr>"),
-                  value = 50, step = 5,
-                  min = 20, max = 100,
-                  pre = "%"),
 
       actButton("hydro.set.apply.target", "Apply custom settings", "update"),
       actButton("hydro.set.reset.target", "Reset custom settings", "grey")

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -162,11 +162,6 @@ hyd.reference.box.settings = function(){
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
                      value = 75)
       ),
-      sliderInput(inputId = "hydro.set.chop.reference",
-                  label = HTML("<abbr title='Using less data increases the speed of the analysis and has a minimal effect on the accuracy of detecting partially inundated cases. (%)'>Partial data search</abbr>"),
-                  value = 50, step = 5,
-                  min = 20, max = 100,
-                  pre = "%"),
       
       actButton("hydro.set.apply.reference", "Apply custom settings", "update"),
       actButton("hydro.set.reset.reference", "Reset custom settings", "grey")

--- a/server.R
+++ b/server.R
@@ -771,8 +771,7 @@ shinyServer(function(input, output, session) {
     return(data.frame(gaps = input$hydro.set.gaps.target,
                       full = input$hydro.set.full.target,
                       part = input$hydro.set.part.target,
-                      tilt = input$hydro.set.tilt.target,
-                      chop = input$hydro.set.chop.target)
+                      tilt = input$hydro.set.tilt.target)
     )
   })
   
@@ -1065,8 +1064,7 @@ shinyServer(function(input, output, session) {
     return(data.frame(gaps = input$hydro.set.gaps.reference,
                       full = input$hydro.set.full.reference,
                       part = input$hydro.set.part.reference,
-                      tilt = input$hydro.set.tilt.reference,
-                      chop = input$hydro.set.chop.reference)
+                      tilt = input$hydro.set.tilt.reference)
     )
   })
   


### PR DESCRIPTION
I've tested the effect of using less data in classifying partially inundated cases to speed up the analysis, and there's no issue. Benchmarking showed that runtimes plateaued at 25% of the data being used. Any less shows no improvement in performance. 

'fun_hydrology.R'
The default value of the 'chop' argument is now 0.25 and I have removed the warning message.

'fun_iu_hydrology.R'
I have removed the slider option in the custom settings.