### PR TITLE
Simpler custom settings and works across all designs

### DIFF
--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -219,7 +219,10 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     mutate(
       Event = recode(Status, 'N' = 0, 'P' = 1, 'F' = 1), # note: P = 1 to include partial cases in event classification and thus inundation duration
       Event = replace(cumsum(!Event), !Event, NA),
-      Event = as.integer(factor((Event))),
+      Event = as.integer(factor((Event)))) %>%
+    # remove any duplicates that may have been introduced:
+    distinct(datetime, .keep_all = T) %>%
+    mutate( 
       # calculate current velocity during full inundation:
       CurrentVelocity = 
            if (design == 'B4'  & rate == 1)  { ifelse(Status == 'F', 2.699136272 + (-0.085824310 * Tilt) + ( 9.862232219e-04 * Tilt ^ 2) + (-4.005656168e-06 * Tilt ^ 3), NA) }

--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -462,7 +462,7 @@ get.stats.text = function(data, design){
     Statistics %>%
       filter(ParameterShort == 'SurveyDays') %>%
       select(Value) %>% round(., 1),
-    ' days</b>, ',
+    ' day(s)</b>, ',
     if (Statistics %>%
         filter(ParameterShort == 'SurveyDays') %>%
         select(Value) < 15)
@@ -511,7 +511,7 @@ get.stats.text = function(data, design){
     Statistics %>%
       filter(ParameterShort == 'MaxWoO') %>%
       select(Value) %>% round(., 1),
-    ' days</b>, ',
+    ' day(s)</b>, ',
     if (Statistics %>%
         filter(ParameterShort == 'MaxWoO') %>%
         select(Value) > 4)

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -54,13 +54,8 @@ hyd.target.box.settings = function(){
                      label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (hours)</abbr>"),
                      value = 1),
         numericInput(inputId = "hydro.set.tilt.target",
-<<<<<<< HEAD
-                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
-                     value = 75, min = 0, max = 90)          
-=======
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated'>Minimun tilt (degrees)</abbr>"),
-                     value = 75)          
->>>>>>> 802e406 (Simpler custom settings and works across all designs)
+                     value = 75, min = 0, max = 90)          
       ),
 
       actButton("hydro.set.apply.target", "Apply custom settings", "update"),
@@ -164,13 +159,8 @@ hyd.reference.box.settings = function(){
                      label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (hours)</abbr>"),
                      value = 1),
         numericInput(inputId = "hydro.set.tilt.reference",
-<<<<<<< HEAD
-                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
-                     value = 75, min = 0, max = 90)          
-=======
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated'>Minimun tilt (degrees)</abbr>"),
-                     value = 75)
->>>>>>> 802e406 (Simpler custom settings and works across all designs)
+                     value = 75, min = 0, max = 90)          
       ),
       
       actButton("hydro.set.apply.reference", "Apply custom settings", "update"),

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -40,22 +40,27 @@ hyd.target.box.settings = function(){
     list(
       uiOutput("hydro.window.target.show"),
 
-      # Default values: gaps = 20, full = 20, part = 90, tilt = 75, chop = 50
+      # Default values: gaps = 1, full = 1, part = 25, tilt = 75
       splitLayout(
         numericInput(inputId = "hydro.set.gaps.target",
-                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated (minutes)'>Minimum gap</abbr>"),
-                     value = 20),
+                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated'>Minimum gap (hours)</abbr>"),
+                     value = 1),
         numericInput(inputId = "hydro.set.part.target",
-                     label = HTML("<abbr title='Time window to search for partially inundated cases at the start and end of inundation events (minutes).'>Search window</abbr>"),
-                     value = 90)
+                     label = HTML("<abbr title='Proportion of the start and end of inundation events to Window to search for partially inundated cases'>Search window (%)</abbr>"),
+                     value = 25)
         ),
       splitLayout(
         numericInput(inputId = "hydro.set.full.target",
-                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated (minutes)'>Minimum duration</abbr>"),
-                     value = 20),
+                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (hours)</abbr>"),
+                     value = 1),
         numericInput(inputId = "hydro.set.tilt.target",
+<<<<<<< HEAD
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
                      value = 75, min = 0, max = 90)          
+=======
+                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated'>Minimun tilt (degrees)</abbr>"),
+                     value = 75)          
+>>>>>>> 802e406 (Simpler custom settings and works across all designs)
       ),
 
       actButton("hydro.set.apply.target", "Apply custom settings", "update"),
@@ -145,22 +150,27 @@ hyd.reference.box.settings = function(){
     list(
       uiOutput("hydro.window.reference.show"),
       
-      # Default values: gaps = 20, full = 20, part = 90, tilt = 75, chop = 50
+      # Default values: gaps = 1, full = 1, part = 50, tilt = 75
       splitLayout(
         numericInput(inputId = "hydro.set.gaps.reference",
-                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated (minutes)'>Minimum gap</abbr>"),
-                     value = 20),
+                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated'>Minimum gap (hours)</abbr>"),
+                     value = 1),
         numericInput(inputId = "hydro.set.part.reference",
-                     label = HTML("<abbr title='Time window to search for partially inundated cases at the start and end of inundation events (minutes).'>Search window</abbr>"),
-                     value = 90)
+                     label = HTML("<abbr title='Proportion of the start and end of inundation events to Window to search for partially inundated cases'>Search window (%)</abbr>"),
+                     value = 25)
       ),
       splitLayout(
         numericInput(inputId = "hydro.set.full.reference",
-                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated (minutes)'>Minimum duration</abbr>"),
-                     value = 20),
+                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (hours)</abbr>"),
+                     value = 1),
         numericInput(inputId = "hydro.set.tilt.reference",
+<<<<<<< HEAD
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated (degrees)'>Minimun tilt</abbr>"),
                      value = 75, min = 0, max = 90)          
+=======
+                     label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated'>Minimun tilt (degrees)</abbr>"),
+                     value = 75)
+>>>>>>> 802e406 (Simpler custom settings and works across all designs)
       ),
       
       actButton("hydro.set.apply.reference", "Apply custom settings", "update"),

--- a/server.R
+++ b/server.R
@@ -761,7 +761,7 @@ shinyServer(function(input, output, session) {
     } else if (is.null(TargetHydroStats())){
       print(text.too.short)
     } else {
-      HTML(get.stats.text(TargetHydroStats()))
+      HTML(get.stats.text(TargetHydroStats(), design = get.design.T()))
     }
   })
   
@@ -847,7 +847,7 @@ shinyServer(function(input, output, session) {
     if (timewindow < 2){
       TargetHydroStats = data.frame()
     } else {
-      TargetHydroStats = get.summary.statisics(TargetHydro)
+      TargetHydroStats = get.summary.statistics(TargetHydro, design = get.design.T())
       }
     return(TargetHydroStats)
   })
@@ -874,8 +874,8 @@ shinyServer(function(input, output, session) {
   
   get.xlsx.object.target = reactive({
     TargetHydro = TargetHydro()
-    stats.daily = get.daily.statistics(TargetHydro)
-    stats.event = get.event.statistics(TargetHydro)
+    stats.daily = get.daily.statistics(TargetHydro, design = get.design.T())
+    stats.event = get.event.statistics(TargetHydro, design = get.design.T())
     stats.summary = TargetHydroStats()
     stats.tidal = get.tidal.statistics(TargetHydro)
     settings = data.frame(gaps = input$hydro.set.gaps.target,
@@ -1144,9 +1144,9 @@ shinyServer(function(input, output, session) {
     if (timewindow < 2){
       ReferenceHydroStats = NULL
     } else {
-      ReferenceHydroStats = get.summary.statisics(ReferenceHydro)
+      ReferenceHydroStats = get.summary.statistics(ReferenceHydro, design = get.design.R())
     }
-    ReferenceHydroStats = get.summary.statisics(values$ReferenceHydro)
+    ReferenceHydroStats = get.summary.statistics(values$ReferenceHydro, design = get.design.R())
     return(ReferenceHydroStats)
   })
   
@@ -1159,7 +1159,7 @@ shinyServer(function(input, output, session) {
     } else if (is.null(ReferenceHydroStats())){
       print(text.too.short)
     } else {
-      HTML(get.stats.text(ReferenceHydroStats()))
+      HTML(get.stats.text(ReferenceHydroStats(), design = get.design.R()))
     }
   })
   
@@ -1185,8 +1185,8 @@ shinyServer(function(input, output, session) {
   
   get.xlsx.object.reference = reactive({
     ReferenceHydro = ReferenceHydro()
-    stats.daily = get.daily.statistics(ReferenceHydro)
-    stats.event = get.event.statistics(ReferenceHydro)
+    stats.daily = get.daily.statistics(ReferenceHydro, design = get.design.R())
+    stats.event = get.event.statistics(ReferenceHydro, design = get.design.R())
     stats.summary = ReferenceHydroStats()
     stats.tidal = get.tidal.statistics(ReferenceHydro)
     settings = data.frame(gaps = input$hydro.set.gaps.reference,
@@ -1365,13 +1365,15 @@ shinyServer(function(input, output, session) {
     TargetHydro = get.overlapping.data(dataset = TargetHydro())
     ReferenceHydro = get.overlapping.data(dataset = ReferenceHydro())
     
-    TargetHydroStats = get.summary.statisics(data = TargetHydro)
-    ReferenceHydroStats = get.summary.statisics(data = ReferenceHydro)
+    TargetHydroStats = get.summary.statistics(data = TargetHydro, design = get.design.T())
+    ReferenceHydroStats = get.summary.statistics(data = ReferenceHydro, design = get.design.R())
     
-    ComparisonStats = get.comparison(hydro.t = TargetHydro,
-                                     hydro.r = ReferenceHydro,
-                                     stats.t = TargetHydroStats,
-                                     stats.r = ReferenceHydroStats)
+    ComparisonStats = get.comparison(hydro.t  = TargetHydro,
+                                     hydro.r  = ReferenceHydro,
+                                     stats.t  = TargetHydroStats,
+                                     stats.r  = ReferenceHydroStats,
+                                     design.t = get.design.T(),
+                                     design.r = get.design.R())
     return(list(Comparison=ComparisonStats, 
                 Target=TargetHydro,
                 Reference=ReferenceHydro)) 


### PR DESCRIPTION
**What's changed**

server.R
- added the 'design' argument so that wave orbital velocity stats are only presented if B4+ is used

fun_ui_hydrology.R
- default gaps and full are now in hours
- default part is now a proportion of the start and end of each individual inundation event. This was changed because users would probably have had to input a unique part value with every unique dataset. A proportional value of 25% seems to work well in general.
- Modified the custom labels and pop-up text to reflect changes in the points above

fun_hydrology.R
- Updated the default values (see previous points)
- chop is now fixed to 0.25
- rate is calculated using difftime to ensure the units are consistently in seconds
- added if statements to only run steps necessary for calculating wave orbital velocity if B4+ is being used
- for Pendant, we're aggregating into 2 minutes, not 10 min
- gaps and full are corrected depending on the sampling rate of the data
- search windows for partial inundation are now done as a proprtion of each inundation event, rather than a single value for the whole dataset
- subsetting data is not done for Pendant, as sampling rate is lower
- Abrupt shift detection fails if there are less than 5 data points in the search window. A new code chunk added to exclude short windows from analysis. A warning is needed here, as values in the search window will default to full inundation
- Corrected the calibration equations to convert tilt to current velocity for B4 and Pendant
- Corrected the FullCheck test that checks if a day has a full dataset
- updated summary / daily / event / text / comparison statistics to only include wave orbital velocity if B4+ is used