### PR TITLE
Corrected several hydrodynamics calculations

### DIFF
--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -357,8 +357,7 @@ get.summary.statistics = function(data, design) {
   if (design == 'B4+') {
     hydro.Summary = rbind.data.frame(
       hydro.Summary,
-      cbind(Parameter = 'Peak wave orbital velocity',    Units = '[m/s]',     hydro.WavePeak(data)),
-      cbind(Parameter = 'Upper wave orbital velocity',   Units = '[m/s]',     hydro.WaveUpperQ(data)),
+      cbind(Parameter = 'Upper wave orbital velocity',   Units = '[m/s]',     hydro.WaveUpper(data)),
       cbind(Parameter = 'Mean wave orbital velocity',    Units = '[m/s]',     hydro.WaveMean(data)),
       cbind(Parameter = 'Median wave orbital velocity',  Units = '[m/s]',     hydro.WaveMed(data)))
   } else { hydro.Summary }
@@ -379,8 +378,7 @@ get.daily.statistics = function(data, design) {
   if (design == 'B4+') {
     hydro.Daily = rbind.data.frame(
       hydro.Daily,
-      cbind(Parameter = 'Peak wave orbital velocity',   Units = '[m/s]', hydro.PeakWaveDay(data)),
-      cbind(Parameter = 'Upper wave orbital velocity',  Units = '[m/s]', hydro.UpperQWaveDay(data)),
+      cbind(Parameter = 'Upper wave orbital velocity',  Units = '[m/s]', hydro.UpperWaveDay(data)),
       cbind(Parameter = 'Mean wave orbital velocity',   Units = '[m/s]', hydro.MeanWaveDay(data)),
       cbind(Parameter = 'Median wave orbital velocity', Units = '[m/s]', hydro.MedWaveDay(data)))
   } else { hydro.Daily }
@@ -399,8 +397,7 @@ get.event.statistics = function(data, design) {
   if (design == 'B4+') {
     hydro.Event = rbind.data.frame(
       hydro.Event,
-      cbind(Parameter = 'Peak wave orbital velocity',   Units = '[m/s]', hydro.PeakWaveEvent(data)),
-      cbind(Parameter = 'Upper wave orbital velocity',  Units = '[m/s]', hydro.UpperQWaveEvent(data)),
+      cbind(Parameter = 'Upper wave orbital velocity',  Units = '[m/s]', hydro.UpperWaveEvent(data)),
       cbind(Parameter = 'Mean wave orbital velocity',   Units = '[m/s]', hydro.MeanWaveEvent(data)),
       cbind(Parameter = 'Median wave orbital velocity', Units = '[m/s]', hydro.MedWaveEvent(data)))
   } else { hydro.Event }
@@ -585,7 +582,7 @@ get.comparison = function(hydro.t, hydro.r, stats.t, stats.r, design.t, design.r
   comparison = left_join(summary.c, event.c, by = c('Parameter', 'Units')) %>%
     filter(Parameter %in% c('Survey days',
                             'Inundation events',
-                            'Mean inundation frequency',
+                            'Inundation frequency',
                             'Maximum Window of Opportunity',
                             'Inundation proportion',
                             'Mean current velocity', 


### PR DESCRIPTION
**What's changed:**
- floor_date is needed in checking whether days have a full dataset or not
- hydro.NumEvents(): moved check for NAs from na.omit() to na.rm = T inside the n_distinct function
- hydro.DurEvents(): the difftime() function seems to leave out 1 value at the end of each inundation event, so have changed the function to count the number of rows that are an event, standardised by the sampling rate
- hydro.DurEventsHrs(): new function to calculate duration of events in hours
- hydro.IndDurDay(): removed the filter to only use days with complete data, as this resulted in different total inundation durations vs summary and event outputs. Will instead add another column to daily.stats that says whether the day contained a full dataset or not. Also corrected so value is divided by time difference, not multiplied
- hydro.NonIndDurDay(): as above
- added two new functions to calculate inundation / emersion per day in hours
- removed peak current, wave orbital velocities, and and ebb-flood ratios throughout, since these are based on max values that can be spurious
- modified 'Upper' current / wave orbital velocities / ebb-flood ratios to give the 95th percentile values, in place of the maximum values
- modified all tables / text to accept the above changes