### PR TITLE
Assigning 'gaps' and 'full' arguments in minutes

### DIFF
--- a/R_scripts/functions/fun_hydrology.R
+++ b/R_scripts/functions/fun_hydrology.R
@@ -16,8 +16,8 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     part = ui.input_settings$part
     tilt = ui.input_settings$tilt
   } else {
-    gaps = 1
-    full = 1
+    gaps = 60
+    full = 60
     part = 25
     tilt = 75
   }
@@ -45,23 +45,8 @@ get.hydrodynamics = function(data, design, ui.input_settings = NULL) {
     ungroup()
   
   # convert gaps and full arguments depending on Mini Buoy aggregation rate:
-  gaps = ifelse(gaps == 0, 
-                gaps,
-                data.NF %>%
-                  group_by(datetime = ceiling_date(datetime, unit = paste(gaps, 'hours'))) %>%
-                  summarise(Count = n()) %>%
-                  ungroup() %>%
-                  summarise(median = median(Count)) %>%
-                  as.numeric())
-  
-  full = ifelse(full == 0,
-                full,
-                data.NF %>%
-                  group_by(datetime = ceiling_date(datetime, unit = paste(full, 'hours'))) %>%
-                  summarise(Count = n()) %>%
-                  ungroup() %>%
-                  summarise(median = median(Count)) %>%
-                  as.numeric())
+  gaps = ceiling(gaps / as.numeric(difftime(data.NF$datetime[2], data.NF$datetime[1], units = 'mins')))
+  full = ceiling(full / as.numeric(difftime(data.NF$datetime[2], data.NF$datetime[1], units = 'mins')))
   
   data.NF = data.NF %>%
     mutate(

--- a/R_scripts/functions/fun_ui_hydrology.R
+++ b/R_scripts/functions/fun_ui_hydrology.R
@@ -41,19 +41,19 @@ hyd.target.box.settings = function(){
     list(
       uiOutput("hydro.window.target.show"),
 
-      # Default values: gaps = 1, full = 1, part = 25, tilt = 75
+      # Default values: gaps = 60, full = 60, part = 25, tilt = 75
       splitLayout(
         numericInput(inputId = "hydro.set.gaps.target",
-                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated'>Minimum gap (hours)</abbr>"),
-                     value = 1),
+                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated'>Minimum gap (minutes)</abbr>"),
+                     value = 60),
         numericInput(inputId = "hydro.set.part.target",
                      label = HTML("<abbr title='Proportion of the start and end of inundation events to Window to search for partially inundated cases'>Search window (%)</abbr>"),
                      value = 25)
         ),
       splitLayout(
         numericInput(inputId = "hydro.set.full.target",
-                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (hours)</abbr>"),
-                     value = 1),
+                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (minutes)</abbr>"),
+                     value = 60),
         numericInput(inputId = "hydro.set.tilt.target",
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated'>Minimun tilt (degrees)</abbr>"),
                      value = 75, min = 0, max = 90)          
@@ -159,19 +159,19 @@ hyd.reference.box.settings = function(){
     list(
       uiOutput("hydro.window.reference.show"),
       
-      # Default values: gaps = 1, full = 1, part = 50, tilt = 75
+      # Default values: gaps = 60, full = 60, part = 50, tilt = 75
       splitLayout(
         numericInput(inputId = "hydro.set.gaps.reference",
-                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated'>Minimum gap (hours)</abbr>"),
-                     value = 1),
+                     label = HTML("<abbr title='Minimum gap in an inundation event to be closed, where points were misclassified as non-inundated'>Minimum gap (minutes)</abbr>"),
+                     value = 60),
         numericInput(inputId = "hydro.set.part.reference",
                      label = HTML("<abbr title='Proportion of the start and end of inundation events to Window to search for partially inundated cases'>Search window (%)</abbr>"),
                      value = 25)
       ),
       splitLayout(
         numericInput(inputId = "hydro.set.full.reference",
-                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (hours)</abbr>"),
-                     value = 1),
+                     label = HTML("<abbr title='Minimum duration of a fully inundated event, otherwise event is reclassified as partially inundated'>Minimum duration (minutes)</abbr>"),
+                     value = 60),
         numericInput(inputId = "hydro.set.tilt.reference",
                      label = HTML("<abbr title='Minimum tilt to classify an event as fully inundated, otherwise event is reclassified as partially inundated'>Minimun tilt (degrees)</abbr>"),
                      value = 75, min = 0, max = 90)          


### PR DESCRIPTION
- Reverted to using minutes instead of hours to specify the 'gaps' and 'full' arguments in the get.hydrodynamics() function. The code wouldn't accept decimal hours.