### PR TITLE
Improved reading of Mini Buoy data

### DIFF
--- a/R_scripts/functions/fun_data.R
+++ b/R_scripts/functions/fun_data.R
@@ -47,19 +47,23 @@ get.rawData = function(inputType, file) { # @Marie: needs to be checked when we 
 #' @param file: uploaded file
 #' @return data.frame
 get.ACCy.B4 = function(file) {
-  # find column names:
-  names = as.character(
-    fread(file, 
-          skip   = grep('*CHANNEL', readLines(file, n = 100)),
-          nrows  = 1,
-          header = F))
-  # read the raw data:
-  rawData = fread(file, skip = "*DATA", header = F)
-  # assign column names:
-  colnames(rawData) <- names
-  # ensure only datetime and y-axis acceleration columns are used:
-  rawData = rawData[, c('TIME', 'ACC y')]
-  colnames(rawData) <- c('datetime', 'Acceleration')
+  # read filtered data:
+  if(readLines(file, n = 1) == c('datetime,Acceleration')) { rawData = fread(file)
+  # read raw data:
+  } else {
+    # find column names:
+    names = as.character(
+      fread(file, 
+            skip   = grep('*CHANNEL', readLines(file, n = 100)),
+            nrows  = 1,
+            header = F))
+    # read the raw data:
+    rawData = fread(file, skip = "*DATA", header = F)
+    # assign column names:
+    colnames(rawData) <- names
+    # ensure only datetime and y-axis acceleration columns are used:
+    rawData = rawData[, c('TIME', 'ACC y')]
+    colnames(rawData) <- c('datetime', 'Acceleration') }
   return(rawData)
 }
 
@@ -68,12 +72,17 @@ get.ACCy.B4 = function(file) {
 #' @param file: uploaded file
 #' @return data.frame
 get.ACCy.Pendant = function(file) {
-  # select data from the row containing headers;
-  rawData = fread(file, skip = "#")
-  # select only date/time and x-axis acceleration columns:
-  rawData = select(rawData, contains(c('Date', 'X Accel')))
-  # assign column names to the first 2 columns:
-  colnames(rawData)[c(1,2)] <- c("datetime", "Acceleration")
+  # read filtered data:
+  if(readLines(file, n = 1) == c('datetime,Acceleration')) { rawData = fread(file) 
+  # read raw data:
+  # read raw data:
+  } else {
+    # select data from the row containing headers;
+    rawData = fread(file, skip = "#")
+    # select only date/time and x-axis acceleration columns:
+    rawData = select(rawData, contains(c('Date', 'X Accel')))
+    # assign column names to the first 2 columns:
+    colnames(rawData)[c(1,2)] <- c("datetime", "Acceleration") }
   return(rawData)
 }
 

--- a/R_scripts/functions/fun_data.R
+++ b/R_scripts/functions/fun_data.R
@@ -35,7 +35,7 @@ get.rawData = function(inputType, file) { # @Marie: needs to be checked when we 
       return(data.frame())
    } else {
      # Transform datetime
-     rawData = unify.datetime(rawData, inputType)
+     rawData = unify.datetime(rawData)
      # Remove NA rows
      rawData = rawData[complete.cases(rawData),]
      return(rawData)

--- a/R_scripts/functions/fun_data.R
+++ b/R_scripts/functions/fun_data.R
@@ -31,7 +31,6 @@ get.rawData = function(inputType, file) { # @Marie: needs to be checked when we 
          an.error.occured <<- TRUE
       })
    }
-
    if (an.error.occured) {
       return(data.frame())
    } else {
@@ -43,87 +42,52 @@ get.rawData = function(inputType, file) { # @Marie: needs to be checked when we 
    }
 }
 
+
 #' Reads raw data (datetime & Acceleration (ACCy)) .
 #' @param file: uploaded file
 #' @return data.frame
 get.ACCy.B4 = function(file) {
-   rawData <- suppressWarnings(fread(file, 
-                                     skip = "*DATA"))
-   # Assign column names to the first 2 columns
-   # If more columns exist a error is thrown (managed in Server.R)
-   colnames(rawData)[c(1,2)] <- c("datetime", "Acceleration")
-   rawData$Acceleration = as.numeric(rawData$Acceleration)
-   return(rawData)
+  # find column names:
+  names = as.character(
+    fread(file, 
+          skip   = grep('*CHANNEL', readLines(file, n = 100)),
+          nrows  = 1,
+          header = F))
+  # read the raw data:
+  rawData = fread(file, skip = "*DATA", header = F)
+  # assign column names:
+  colnames(rawData) <- names
+  # ensure only datetime and y-axis acceleration columns are used:
+  rawData = rawData[, c('TIME', 'ACC y')]
+  colnames(rawData) <- c('datetime', 'Acceleration')
+  return(rawData)
 }
 
 
-#' Reads raw data (datetime & Acceleration (ACCy)) .
+#' Reads raw data (datetime & Acceleration (ACCx)) .
 #' @param file: uploaded file
 #' @return data.frame
 get.ACCy.Pendant = function(file) {
-   rawData <- suppressWarnings(fread(file, 
-                                     skip = "#"))[, -1]
-   # Assign column names to the first 2 columns
-   # If more columns exist a error is thrown (managed in Server.R)
-   colnames(rawData)[c(1,2)] <- c("datetime", "Acceleration")
-   # Assign column names to the first 2 columns
-   # If more columns exist a error is thrown (managed in Server.R)
-   rawData$Acceleration = as.numeric(rawData$Acceleration)
-   # Remove rows blank Acc. rows
-   rawData = rawData[!is.na(rawData$Acceleration),]
-   # Find columns that are empty
-   columns <- sapply(rawData, function(x) all(is.na(x) | x == ""))
-   empty_columns = names(columns[columns])
-   # Remove empty columns
-   rawData = rawData %>% select(-all_of(empty_columns)) 
-   if (length(empty_columns) > 0){
-      showNotification(paste("Warning:", length(empty_columns),
-                             "empty columns were removed.",
-                             sep = " "),
-                       type = "warning", duration = 5, closeButton = T)
-   }
-   return(rawData)
-}
-
-unify.datetime = function(rawData, inputType){
-  print("Transform datetime to date and time")
-  an.error.occured = F
-  
-  if (inputType == "Pendant") {
-    tryCatch( 
-      {
-        rawData = rawData %>% rowwise() %>% 
-          mutate(datetime = as.POSIXlt(datetime,
-                                        tz = "GMT", 
-                                        format = c("%m/%d/%y %H:%M:%OS")))
-        
-      },
-      
-      error = function(e) {
-        an.error.occured <<- TRUE
-      })
-  }
-  if (an.error.occured | inputType != "Pendant"){
-    rawData$datetime = fastPOSIXct(rawData$datetime, tz="GMT")
-  }
-   # rawData$date = lubridate::as_date(rawData$datetime)
-   # rawData$time = format(rawData$datetime, format = "%H:%M:%S") #@Marie @Ale: too slow?
-   return(rawData)
+  # select data from the row containing headers;
+  rawData = fread(file, skip = "#")
+  # select only date/time and x-axis acceleration columns:
+  rawData = select(rawData, contains(c('Date', 'X Accel')))
+  # assign column names to the first 2 columns:
+  colnames(rawData)[c(1,2)] <- c("datetime", "Acceleration")
+  return(rawData)
 }
 
 
-#' Convert character time HH:MM:SS to decimal time
-#' @param time: time object or character
-#' @return numeric
-convertTimeToDeci <- function(time) { #@Marie: delete?
-   dt = sapply(strsplit(time, ":"),
-               function(x) {
-                  x <- as.numeric(x)
-                  x[1] + x[2] / 60 + x[3] / 3600
-               })
-   dt = round(dt, 2)
-   return(dt)
+# Possibility to add more datetime formats if they occur:
+unify.datetime = function(rawData){
+  rawData$datetime =
+    # standardise datetime if format is month-day-year 12 hour clock:
+             if(is(tryCatch(mdy_hms(rawData$datetime), warning = function(w) w), 'warning') == F) { mdy_hms(rawData$datetime)
+    # standardise datetime if format is day-month-year 24 hour clock:
+      } else if(is(tryCatch(ymd_hms(rawData$datetime), warning = function(w) w), 'warning') == F) { ymd_hms(rawData$datetime) }
+  return(rawData)
 }
+
 
 #' Function to calculate the time window overlap of 
 #' target and reference data in days
@@ -171,14 +135,14 @@ get.rawData.sum = function(data, type){
       }
       
       coln = paste(tolower(colnames(data)), collapse = ", ")
-      meanAcc = mean(data$Acceleration)
+      meanAcc = mean(data$Acceleration, na.rm = T)
       mAmm = paste(as.character(round(meanAcc, 2)), " (",
                    as.character(round(min(data$Acceleration, na.rm = T), 2)), ", ",
                    as.character(round(max(data$Acceleration, na.rm = T), 2)), ")", 
                    collapse = "")
-      mAqq = paste(as.character(round(median(data$Acceleration), 2)), " (",
-                   as.character(round(quantile(data$Acceleration, 0.25), 2)), ", ",
-                   as.character(round(quantile(data$Acceleration, 0.55), 2)), ")", 
+      mAqq = paste(as.character(round(median(data$Acceleration, na.rm = T), 2)), " (",
+                   as.character(round(quantile(data$Acceleration, 0.25, na.rm = T), 2)), ", ",
+                   as.character(round(quantile(data$Acceleration, 0.55, na.rm = T), 2)), ")", 
                    collapse = "")
       
       tab = data.frame(Variable = c("Column names",

--- a/server.R
+++ b/server.R
@@ -733,9 +733,12 @@ shinyServer(function(input, output, session) {
   ## Info Texts        ####
   
   
-  
+  # if bool.no.target
   text.upload.missing = "No analysis available. Please upload data."
-  text.too.short = "Uploaded/ filtered data set < 2 days."
+  # is.null
+  text.too.short = "Uploaded/ filtered dataset < 2 days."
+  # nrow == 0
+  text.refine.settings = "An error occured. Try refining the default settings."
   
   ## Functions for both R&T   ####
   
@@ -766,6 +769,8 @@ shinyServer(function(input, output, session) {
     if (bool.no.target()){
       print(text.upload.missing)
     } else if (is.null(TargetHydroStats())){
+      print(text.refine.settings)
+    } else if (nrow(TargetHydroStats()) == 0){
       print(text.too.short)
     } else {
       HTML(get.stats.text(TargetHydroStats(), design = get.design.T()))
@@ -862,9 +867,9 @@ shinyServer(function(input, output, session) {
         an.error.occured <<- TRUE
       })
       if (an.error.occured){
-        showNotification("An error occured. Try refining the default settings.",
+        showNotification(text.refine.settings,
                          type = "error", closeButton = T, duration = NULL)
-        TargetHydroStats = data.frame()
+        TargetHydroStats = NULL
       }
     }
     return(TargetHydroStats)
@@ -880,6 +885,9 @@ shinyServer(function(input, output, session) {
         return(tab.with.file.upload.message(text.upload.missing,
                                             color = "black", backgroundColor = "white"))
       } else if (is.null(TargetHydroStats())) {
+        return(tab.with.file.upload.message(text.refine.settings,
+                                            color = "black", backgroundColor = "white"))
+      } else if (nrow(TargetHydroStats()) == 0) {
         return(tab.with.file.upload.message(text.too.short,
                                             color = "black", backgroundColor = "white"))
       } else {
@@ -950,6 +958,8 @@ shinyServer(function(input, output, session) {
     if (bool.no.target()){
       plot.emptyMessage("No figure available. Please upload data.")
     } else if (is.null(TargetHydroStats())) {
+      plot.emptyMessage(text.refine.settings)
+    } else if (nrow(TargetHydroStats()) == 0) {
       plot.emptyMessage(text.too.short)
     } else {
       actual.plot.function
@@ -1189,7 +1199,7 @@ shinyServer(function(input, output, session) {
     ReferenceHydro = ReferenceHydro()
     timewindow = difftime(max(ReferenceHydro$datetime), min(ReferenceHydro$datetime), units = "days")
     if (timewindow < 2){
-      ReferenceHydroStats = NULL
+      ReferenceHydroStats = data.frame()
     } else {
       an.error.occured = F
       tryCatch({
@@ -1199,9 +1209,9 @@ shinyServer(function(input, output, session) {
         an.error.occured <<- TRUE
       })
       if (an.error.occured){
-        showNotification("An error occured. Try refining the default settings.",
+        showNotification(text.refine.settings,
                          type = "error", closeButton = T, duration = NULL)
-        ReferenceHydroStats = data.frame()
+        ReferenceHydroStats = NULL
       }
     }
     return(ReferenceHydroStats)
@@ -1214,6 +1224,8 @@ shinyServer(function(input, output, session) {
     if (bool.no.reference()){
       print(text.upload.missing)
     } else if (is.null(ReferenceHydroStats())){
+      print(text.refine.settings)
+    } else if (nrow(ReferenceHydroStats()) == 0){
       print(text.too.short)
     } else {
       HTML(get.stats.text(ReferenceHydroStats(), design = get.design.R()))
@@ -1231,7 +1243,11 @@ shinyServer(function(input, output, session) {
         return(tab.with.file.upload.message(text.upload.missing,
                                             color = "blue", backgroundColor = "white"))
       } else if (is.null(ReferenceHydroStats())){
-        print(text.too.short)
+        return(tab.with.file.upload.message(text.refine.settings,
+                                            color = "black", backgroundColor = "white"))
+      } else if (nrow(ReferenceHydroStats()) == 0){
+        return(tab.with.file.upload.message(text.too.short,
+                                            color = "black", backgroundColor = "white"))
       } else {
         return(ReferenceHydroStats() %>%
                  mutate_if(is.numeric, round, 2))
@@ -1299,6 +1315,8 @@ shinyServer(function(input, output, session) {
     if (bool.no.reference()){
       plot.emptyMessage("No figure available. Please upload data.")
     } else if (is.null(ReferenceHydroStats())) {
+      plot.emptyMessage(text.refine.settings)
+    } else if (nrow(ReferenceHydroStats()) == 0) {
       plot.emptyMessage(text.too.short)
     } else {
       actual.plot.function

--- a/server.R
+++ b/server.R
@@ -862,7 +862,7 @@ shinyServer(function(input, output, session) {
         an.error.occured <<- TRUE
       })
       if (an.error.occured){
-        showNotification("An error occured. Refine settings.",
+        showNotification("An error occured. Try refining the default settings.",
                          type = "error", closeButton = T, duration = NULL)
         TargetHydroStats = data.frame()
       }
@@ -1199,7 +1199,7 @@ shinyServer(function(input, output, session) {
         an.error.occured <<- TRUE
       })
       if (an.error.occured){
-        showNotification("An error occured. Refine settings.",
+        showNotification("An error occured. Try refining the default settings.",
                          type = "error", closeButton = T, duration = NULL)
         ReferenceHydroStats = data.frame()
       }

--- a/server.R
+++ b/server.R
@@ -854,8 +854,19 @@ shinyServer(function(input, output, session) {
     if (timewindow < 2){
       TargetHydroStats = data.frame()
     } else {
-      TargetHydroStats = get.summary.statistics(TargetHydro, design = get.design.T())
+      an.error.occured = F
+      tryCatch({
+        TargetHydroStats = get.summary.statistics(TargetHydro, design = get.design.T())
+      },
+      error = function(e) {
+        an.error.occured <<- TRUE
+      })
+      if (an.error.occured){
+        showNotification("An error occured. Refine settings.",
+                         type = "error", closeButton = T, duration = NULL)
+        TargetHydroStats = data.frame()
       }
+    }
     return(TargetHydroStats)
   })
   
@@ -1180,9 +1191,19 @@ shinyServer(function(input, output, session) {
     if (timewindow < 2){
       ReferenceHydroStats = NULL
     } else {
-      ReferenceHydroStats = get.summary.statistics(ReferenceHydro, design = get.design.R())
+      an.error.occured = F
+      tryCatch({
+        ReferenceHydroStats = get.summary.statistics(ReferenceHydro, design = get.design.R())
+      },
+      error = function(e) {
+        an.error.occured <<- TRUE
+      })
+      if (an.error.occured){
+        showNotification("An error occured. Refine settings.",
+                         type = "error", closeButton = T, duration = NULL)
+        ReferenceHydroStats = data.frame()
+      }
     }
-    ReferenceHydroStats = get.summary.statistics(values$ReferenceHydro, design = get.design.R())
     return(ReferenceHydroStats)
   })
   


### PR DESCRIPTION
- B4/B4+: users may select the wrong axes (x, z), so  this code takes the column names (including axis) from *CHANNEL column and assigns it to the *DATA column names. This is a more robust way to ensure the correct data is used for the analysis. A warning / error message may be needed if no Yacc data is provided.
- Pendant: reading data is simpler now, using the contains() function to look for the correct headers (date and x accel)
- Standardising datetime: The previous code wasn't working for Pendant data with 12 hour clock (PM data was being superimposed on AM data, leaving gaps where PM should be). Now, a nested if else statment looks for a date format (lubridate) and transforms into a standard yy-mm-dd hh-mm-ss if applicable. At the moment, mdy_hms() and ymd_hms() are being used, with the possibility of adding more options.
- Raw data was not being reported for the Skinflats Pendant test, had to add na.rm = T in the quanitle() function.